### PR TITLE
updated readme links to point to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ easy to fork and contribute any changes back upstream.
 1. Check out phpenv into `~/.phpenv`.
 
         $ cd
-        $ git clone git://github.com/humanshell/phpenv.git .phpenv
+        $ git clone git://github.com/phpenv/phpenv.git .phpenv
 
 2. Add `~/.phpenv/bin` to your `$PATH` for access to the `phpenv`
    command-line utility.
@@ -244,14 +244,14 @@ run the given command.
 ## Development
 
 The phpenv source code is [hosted on
-GitHub](https://github.com/humanshell/phpenv). It's clean, modular,
+GitHub](https://github.com/phpenv/phpenv). It's clean, modular,
 and easy to understand (thanks to the rbenv project), even if you're not a
 shell hacker.
 
 This project is basically a clone (Read: "search and replace") of the rbenv
 project. It's in need of love and support. If you're interested in improving it
 please feel free to fork, submit pull requests and file bugs on the [issue
-tracker](https://github.com/humanshell/phpenv/issues).
+tracker](https://github.com/phpenv/phpenv/issues).
 
 ### License
 


### PR DESCRIPTION
@nickl,

I've updated the links in the readme (on the dev branch) to point to the new repo. It might be confusing to people if they come to the phpenv/phpenv repo and the instructions tell them to install from humanshell/phpenv.
