### PR TITLE
Use plumbing version of git command to retrieve the current working branch

### DIFF
--- a/libexec/phpenv-install
+++ b/libexec/phpenv-install
@@ -187,8 +187,7 @@ function is_linux() {
 # gets latest code from github repo
 function fetch_releases() {
   continue_after 0 "Fetching" && return
-
-  if ${GIT} branch|grep -q '* master'; then
+  if ${GIT} rev-parse --abbrev-ref HEAD | grep -q "master"; then
     log "Fetching" "latest code from Github repo"
     ${GIT} fetch --tags &> /dev/null
   else


### PR DESCRIPTION
When I had first downloaded this to give it a whirl and tried to list the branches I kept getting.

```
phpenv v0.0.4-dev

Already on 'master'
```

Turns out this was because of the following check to see if the current php-src checkout was @ master was returning false all of the time when it was on master because I am using colored output for git.  

``` bash

if ${GIT} branch | grep -q "* master"; then

```

To prevent this we should use the ~~plumbing~~ command `rev-parse` instead of the ~~porcelain~~ command `branch`.

Actually after looking further it is still a porcelain command, but a porcelain ancillary command. I am not sure if it would be necessary to figure out a plumbing way to accomplish this or not.

For reference:
- http://stackoverflow.com/questions/1417957/show-just-the-current-branch-in-git
  
  A discussion on retrieving the current branch for a git repo.
- http://git-scm.com/book/en/Git-Internals-Plumbing-and-Porcelain
- http://schacon.github.io/git/git.html#_high_level_commands_porcelain
- http://schacon.github.io/git/git.html#_low_level_commands_plumbing
  
  Plumbing/Porcelain
- https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html

-- Jonathan
