### PR TITLE
Is changeable protocol (HTTPS) accessing github??

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,34 +1,34 @@
 [submodule "php-ext/igbinary"]
 	path = php-ext/igbinary
-	url = git://github.com/igbinary/igbinary.git
+	url = https://github.com/igbinary/igbinary.git
 [submodule "php-ext/xdebug"]
 	path = php-ext/xdebug
-	url = git://github.com/xdebug/xdebug.git
+	url = https://github.com/xdebug/xdebug.git
 [submodule "php-ext/uri-template"]
 	path = php-ext/uri-template
-	url = git://github.com/ioseb/uri-template.git
+	url = https://github.com/ioseb/uri-template.git
 [submodule "php-ext/apc"]
 	path = php-ext/apc
-	url = git://github.com/nickl-/pecl-apc.git
+	url = https://github.com/nickl-/pecl-apc.git
 [submodule "php-ext/memcached"]
 	path = php-ext/memcached
-	url = git://github.com/php-memcached-dev/php-memcached.git
+	url = https://github.com/php-memcached-dev/php-memcached.git
 [submodule "php-ext/http"]
 	path = php-ext/http
-	url = git://github.com/nickl-/pecl-http.git
+	url = https://github.com/nickl-/pecl-http.git
 [submodule "php-ext/ncurses"]
 	path = php-ext/ncurses
-	url = git://github.com/nickl-/pecl-ncurses.git
+	url = https://github.com/nickl-/pecl-ncurses.git
 [submodule "php-ext/phalcon"]
 	path = php-ext/phalcon
-	url = git://github.com/phalcon/cphalcon.git
+	url = https://github.com/phalcon/cphalcon.git
 [submodule "php-ext/yaf"]
 	path = php-ext/yaf
 	url = https://github.com/laruence/php-yaf
 
 [submodule "php-ext/mongo"]
 	path = php-ext/mongo
-	url = git://github.com/mongodb/mongo-php-driver.git
+	url = https://github.com/mongodb/mongo-php-driver.git
 [submodule "php-ext/.xhprof"]
 	path = php-ext/.xhprof
 	url = https://github.com/facebook/xhprof

--- a/libexec/phpenv-install
+++ b/libexec/phpenv-install
@@ -552,7 +552,7 @@ function clean_repository() {
 # ---------------------
 GIT=$(which git)
 SRC_DIR="$PHPENV_ROOT/php-src"
-SRC_URL="git://github.com/php/php-src.git"
+SRC_URL="https://github.com/php/php-src.git"
 
 # Provide phpenv completions
 if [ "$1" = "--complete" ]; then


### PR DESCRIPTION
phpenv/phpenv is using protocol of git(9418) at the following actions:
- submodules (.gitmodules)
- clone php-src (libexec/phpenv-install)

However protocol of git is often blocked by corporate firewalls

Does not change the protocol of HTTPS?

If you agree to this proposal, I'll send [PR](https://github.com/nishigori/phpenv/commit/faa254b)

Please see more: [The Git Protocol >> The Cons - git-scm.com - ](http://git-scm.com/book/ch4-1.html#The-Git-Protocol)
