### PR TITLE
Using newer bison versions

### DIFF
--- a/libexec/phpenv-install
+++ b/libexec/phpenv-install
@@ -529,7 +529,7 @@ function configure_release() {
   phpenv-hooks install pre-configure
 
   # Compiling PHP with Bison 2.7+
-  sed -i -e 's/2.4.2 2.4.3 2.5/& 2.7 3.0/' configure
+  sed -i -r 's/(bison_version_list=.*)"/\1 2.7 3.0"/' configure
   # Compiling PHP with Bison x.y.any.version.scheme.your.distro.want
   sed -i -r "s;(bison_version_vars=.*)/ /'(.*);\1/ /g\2;" configure
 

--- a/libexec/phpenv-install
+++ b/libexec/phpenv-install
@@ -527,6 +527,12 @@ function configure_release() {
   rm -rf configure autom4te.cache
   ./buildconf --force
   phpenv-hooks install pre-configure
+
+  # Compiling PHP with Bison 2.7+
+  sed -i -e 's/2.4.2 2.4.3 2.5/& 2.7 3.0/' configure
+  # Compiling PHP with Bison x.y.any.version.scheme.your.distro.want
+  sed -i -r "s;(bison_version_vars=.*)/ /'(.*);\1/ /g\2;" configure
+
   ./configure $argv
   phpenv-hooks install post-configure
 


### PR DESCRIPTION
Accepting Bison 2.7+ when compiling PHP 5.{3,4};
Accepting Bison versions as 2.7.12-4996
