### PR TITLE
Feature/readme Correct Branch is master for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ easy to fork and contribute any changes back upstream.
 1. Check out phpenv into `~/.phpenv`.
 
         $ cd
-        $ git clone git://github.com/phpenv/phpenv.git .phpenv
+        $ git clone -b master git://github.com/phpenv/phpenv.git .phpenv
 
 2. Add `~/.phpenv/bin` to your `$PATH` for access to the `phpenv`
    command-line utility.


### PR DESCRIPTION
Default branch which gets cloned is dev. Specifying which branch to clone in README 

Fixes: #19