### PR TITLE
Determine EDITOR based on user environment before falling back on vi

### DIFF
--- a/libexec/phpenv-configure
+++ b/libexec/phpenv-configure
@@ -4,4 +4,20 @@
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
-vi "$(php --ini|grep Loaded|awk '{print $NF}')"
+if [ "$VISUAL" ]; then
+	cmd="$VISUAL"
+fi
+
+if ! [ "$cmd" ] && [ "$EDITOR" ]; then
+	cmd="$EDITOR"
+fi
+
+if ! [ "$cmd" ] && type vim >/dev/null 2>&1; then
+	cmd="vim"
+fi
+
+if ! [ "$cmd" ]; then
+	cmd="vi"
+fi
+
+"$cmd" "$(php --ini|grep Loaded|awk '{print $NF}')"


### PR DESCRIPTION
Based on @glensc suggestion. Only fallback on hardcoded `vi` if EDITOR and VISUAL are not defined.

https://github.com/phpenv/phpenv/pull/85/files/1258322d9be047f79f5e20b99f17e6ac7276d9b8#r222902777