### PR TITLE
Fix git clone URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ easy to fork and contribute any changes back upstream.
 
 1. Check out phpenv into `~/.phpenv`.
 
-        $ git clone git://github.com/phpenv/phpenv.git ~/.phpenv
+        $ git clone git@github.com:phpenv/phpenv.git ~/.phpenv
 
 2. Add `~/.phpenv/bin` to your `$PATH` for access to the `phpenv`
    command-line utility.


### PR DESCRIPTION
```
$ git clone git://github.com/phpenv/phpenv.git
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

![image](https://user-images.githubusercontent.com/4192479/159138604-3ed89482-2fe8-42e7-b7a9-b531199aa582.png)
