### PR TITLE
Bats tests - phpenv-commands, phpenv-which, phpenv-version-origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ GitHub][phpenv-url]. It's clean, modular,
 and easy to understand (thanks to the rbenv project), even if you're not a
 shell hacker.
 
-Tests are executed using [Bats](https://github.com/bats-core/bats-code):
+Tests are executed using [Bats](https://github.com/bats-core/bats-core):
 
     $ bats test
     $ bats test/<file>.bats

--- a/README.md
+++ b/README.md
@@ -258,10 +258,16 @@ GitHub][phpenv-url]. It's clean, modular,
 and easy to understand (thanks to the rbenv project), even if you're not a
 shell hacker.
 
+Tests are executed using [Bats](https://github.com/bats-core/bats-code):
+
+    $ bats test
+    $ bats test/<file>.bats
+
 This project is basically a clone (Read: "search and replace") of the rbenv
 project. It's in need of love and support. If you're interested in improving it
 please feel free to fork, submit [pull requests][phpenv-prs] and file bugs on the [issue
 tracker][phpenv-issues].
+
 
 ### License
 

--- a/libexec/phpenv---version
+++ b/libexec/phpenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
-version="0.9.0-rc.1"
+version="1.0.0-rc.1"
 git_revision=""
 
 cd "$PHPENV_ROOT"

--- a/libexec/phpenv-commands
+++ b/libexec/phpenv-commands
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Summary: List all available phpenv commands
 # Usage: phpenv commands [--sh|--no-sh]
+#
+# List names of all phpenv commands, including 3rd-party ones found in the
+# PATH or in phpenv plugins. With `--sh`, list only shell commands.
+#
+# This functionality is mainly meant for scripting. To see usage help for
+# phpenv, run `phpenv help`.
 
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
@@ -12,30 +18,33 @@ if [ "$1" = "--complete" ]; then
   exit
 fi
 
+exclude_shell=
+command_prefix="phpenv-"
+
 if [ "$1" = "--sh" ]; then
-  sh=1
+  command_prefix="phpenv-sh-"
   shift
 elif [ "$1" = "--no-sh" ]; then
-  nosh=1
+  exclude_shell=1
   shift
 fi
 
 shopt -s nullglob
 
-{ for path in ${PATH//:/$'\n'}; do
-    for command in "${path}/phpenv-"*; do
-      command="${command##*phpenv-}"
-      if [ -n "$sh" ]; then
-        if [ ${command:0:3} = "sh-" ]; then
-          echo ${command##sh-}
+{
+  PATH_remain="$PATH"
+  # traverse PATH to find "phpenv-" prefixed commands
+  while true; do
+    path="${PATH_remain%%:*}"
+    if [ -n "$path" ]; then
+      for phpenv_command in "${path}/${command_prefix}"*; do
+        phpenv_command="${phpenv_command##*phpenv-}"
+        if [[ -z $exclude_shell || $phpenv_command != sh-* ]]; then
+          echo "${phpenv_command##sh-}"
         fi
-      elif [ -n "$nosh" ]; then
-        if [ ${command:0:3} != "sh-" ]; then
-          echo ${command##sh-}
-        fi
-      else
-        echo ${command##sh-}
-      fi
-    done
+      done
+    fi
+    [[ $PATH_remain == *:* ]] || break
+    PATH_remain="${PATH_remain#*:}"
   done
 } | sort | uniq

--- a/libexec/phpenv-version-name
+++ b/libexec/phpenv-version-name
@@ -26,6 +26,6 @@ elif version_exists "${PHPENV_VERSION#php-}"; then
   } >&2
   echo "${PHPENV_VERSION#php-}"
 else
-  echo "phpenv: version \`$PHPENV_VERSION' is not installed" >&2
+  echo "phpenv: version \`$PHPENV_VERSION' is not installed (set by $(phpenv-version-origin))" >&2
   exit 1
 fi

--- a/libexec/phpenv-version-origin
+++ b/libexec/phpenv-version-origin
@@ -3,6 +3,12 @@
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
+IFS=$'\n' read -d '' -r -a scripts <<<"$(phpenv-hooks version-origin)" || true
+for script in "${scripts[@]}"; do
+  # shellcheck disable=SC1090
+  source "$script"
+done
+
 if [ -n "$PHPENV_VERSION" ]; then
   echo "PHPENV_VERSION environment variable"
 else

--- a/libexec/phpenv-version-origin
+++ b/libexec/phpenv-version-origin
@@ -3,13 +3,17 @@
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
+unset PHPENV_VERSION_ORIGIN
+
 IFS=$'\n' read -d '' -r -a scripts <<<"$(phpenv-hooks version-origin)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"
 done
 
-if [ -n "$PHPENV_VERSION" ]; then
+if [ -n "$PHPENV_VERSION_ORIGIN" ]; then
+  echo "$PHPENV_VERSION_ORIGIN"
+elif [ -n "$PHPENV_VERSION" ]; then
   echo "PHPENV_VERSION environment variable"
 else
   phpenv-version-file

--- a/test/commands.bats
+++ b/test/commands.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "commands" {
+  run phpenv-commands
+  assert_success
+  assert_line "init"
+  assert_line "rehash"
+  assert_line "shell"
+  refute_line "sh-shell"
+  assert_line "echo"
+}
+
+@test "commands --sh" {
+  run phpenv-commands --sh
+  assert_success
+  refute_line "init"
+  assert_line "shell"
+}
+
+@test "commands in path with spaces" {
+  path="${PHPENV_TEST_DIR}/my commands"
+  cmd="${path}/phpenv-sh-hello"
+  mkdir -p "$path"
+  touch "$cmd"
+  chmod +x "$cmd"
+
+  PATH="${path}:$PATH" run phpenv-commands --sh
+  assert_success
+  assert_line "hello"
+}
+
+@test "commands --no-sh" {
+  run phpenv-commands --no-sh
+  assert_success
+  assert_line "init"
+  refute_line "shell"
+}

--- a/test/libexec/phpenv-echo
+++ b/test/libexec/phpenv-echo
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Usage: phpenv echo [-F<char>] VAR
+
+if [[ $1 == -F* ]]; then
+  sep="${1:2}"
+  echo "${!2}" | tr "${sep:-:}" $'\n'
+else
+  echo "${!1}"
+fi

--- a/test/run
+++ b/test/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+exec bats ${CI:+--tap} "${@:-test}"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,131 @@
+unset PHPENV_VERSION
+unset PHPENV_DIR
+
+# guard against executing this block twice due to bats internals
+if [ -z "$PHPENV_TEST_DIR" ]; then
+  PHPENV_TEST_DIR="${BATS_TMPDIR}/phpenv"
+  export PHPENV_TEST_DIR="$(mktemp -d "${PHPENV_TEST_DIR}.XXX" 2>/dev/null || echo "$PHPENV_TEST_DIR")"
+
+  export PHPENV_ROOT="${PHPENV_TEST_DIR}/root"
+  export HOME="${PHPENV_TEST_DIR}/home"
+  export PHPENV_HOOK_PATH="${PHPENV_ROOT}/phpenv.d"
+
+  PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+  PATH="${PHPENV_TEST_DIR}/bin:$PATH"
+  PATH="${BATS_TEST_DIRNAME}/../libexec:$PATH"
+  PATH="${BATS_TEST_DIRNAME}/libexec:$PATH"
+  PATH="${PHPENV_ROOT}/shims:$PATH"
+  export PATH
+
+  for xdg_var in `env 2>/dev/null | grep ^XDG_ | cut -d= -f1`; do unset "$xdg_var"; done
+  unset xdg_var
+fi
+
+teardown() {
+  rm -rf "$PHPENV_TEST_DIR"
+}
+
+flunk() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } | sed "s:${PHPENV_TEST_DIR}:TEST_DIR:g" >&2
+  return 1
+}
+
+assert_success() {
+  if [ "$status" -ne 0 ]; then
+    flunk "command failed with exit status $status"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_failure() {
+  if [ "$status" -eq 0 ]; then
+    flunk "expected failed exit status"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_equal() {
+  if [ "$1" != "$2" ]; then
+    { echo "expected: $1"
+      echo "actual:   $2"
+    } | flunk
+  fi
+}
+
+assert_output() {
+  local expected
+  if [ $# -eq 0 ]; then expected="$(cat -)"
+  else expected="$1"
+  fi
+  assert_equal "$expected" "$output"
+}
+
+assert_line() {
+  if [ "$1" -ge 0 ] 2>/dev/null; then
+    assert_equal "$2" "${lines[$1]}"
+  else
+    local line
+    for line in "${lines[@]}"; do
+      if [ "$line" = "$1" ]; then return 0; fi
+    done
+    flunk "expected line \`$1'"
+  fi
+}
+
+refute_line() {
+  if [ "$1" -ge 0 ] 2>/dev/null; then
+    local num_lines="${#lines[@]}"
+    if [ "$1" -lt "$num_lines" ]; then
+      flunk "output has $num_lines lines"
+    fi
+  else
+    local line
+    for line in "${lines[@]}"; do
+      if [ "$line" = "$1" ]; then
+        flunk "expected to not find line \`$line'"
+      fi
+    done
+  fi
+}
+
+assert() {
+  if ! "$@"; then
+    flunk "failed: $@"
+  fi
+}
+
+# Output a modified PATH that ensures that the given executable is not present,
+# but in which system utils necessary for phpenv operation are still available.
+path_without() {
+  local exe="$1"
+  local path=":${PATH}:"
+  local found alt util
+  for found in $(type -aP "$exe"); do
+    found="${found%/*}"
+    if [ "$found" != "${PHPENV_ROOT}/shims" ]; then
+      alt="${PHPENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
+      mkdir -p "$alt"
+      for util in bash head cut readlink greadlink sed sort awk; do
+        if [ -x "${found}/$util" ]; then
+          ln -s "${found}/$util" "${alt}/$util"
+        fi
+      done
+      path="${path/:${found}:/:${alt}:}"
+    fi
+  done
+  path="${path#:}"
+  echo "${path%:}"
+}
+
+create_hook() {
+  mkdir -p "${PHPENV_HOOK_PATH}/$1"
+  touch "${PHPENV_HOOK_PATH}/$1/$2"
+  if [ ! -t 0 ]; then
+    cat > "${PHPENV_HOOK_PATH}/$1/$2"
+  fi
+}

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  mkdir -p "$PHPENV_TEST_DIR"
+  cd "$PHPENV_TEST_DIR"
+}
+
+@test "reports global file even if it doesn't exist" {
+  assert [ ! -e "${PHPENV_ROOT}/version" ]
+  run phpenv-version-origin
+  assert_success "${PHPENV_ROOT}/version"
+}
+
+@test "detects global file" {
+  mkdir -p "$PHPENV_ROOT"
+  touch "${PHPENV_ROOT}/version"
+  run phpenv-version-origin
+  assert_success "${PHPENV_ROOT}/version"
+}
+
+@test "detects PHPENV_VERSION" {
+  PHPENV_VERSION=1 run phpenv-version-origin
+  assert_success "PHPENV_VERSION environment variable"
+}
+
+@test "detects local file" {
+  echo "system" > .php-version
+  run phpenv-version-origin
+  assert_success "${PWD}/.php-version"
+}
+
+@test "reports from hook" {
+  create_hook version-origin test.bash <<<"PHPENV_VERSION_ORIGIN=plugin"
+
+  PHPENV_VERSION=1 run phpenv-version-origin
+  assert_success "plugin"
+}
+
+@test "carries original IFS within hooks" {
+  create_hook version-origin hello.bash <<SH
+hellos=(\$(printf "hello\\tugly world\\nagain"))
+echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
+SH
+
+  export PHPENV_VERSION=system
+  IFS=$' \t\n' run phpenv-version-origin env
+  assert_success
+  assert_line "HELLO=:hello:ugly:world:again"
+}
+
+@test "doesn't inherit PHPENV_VERSION_ORIGIN from environment" {
+  PHPENV_VERSION_ORIGIN=ignored run phpenv-version-origin
+  assert_success "${PHPENV_ROOT}/version"
+}

--- a/test/which.bats
+++ b/test/which.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_executable() {
+  local bin
+  if [[ $1 == */* ]]; then bin="$1"
+  else bin="${PHPENV_ROOT}/versions/${1}/bin"
+  fi
+  mkdir -p "$bin"
+  touch "${bin}/$2"
+  chmod +x "${bin}/$2"
+}
+
+@test "outputs path to executable" {
+  create_executable "7.4.33" "php"
+  create_executable "8.1.16" "pecl"
+
+  PHPENV_VERSION=7.4.33 run phpenv-which php
+  assert_success "${PHPENV_ROOT}/versions/7.4.33/bin/php"
+
+  PHPENV_VERSION=8.1.16 run phpenv-which pecl
+  assert_success "${PHPENV_ROOT}/versions/8.1.16/bin/pecl"
+}
+
+@test "searches PATH for system version" {
+  create_executable "${PHPENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${PHPENV_ROOT}/shims" "kill-all-humans"
+
+  PHPENV_VERSION=system run phpenv-which kill-all-humans
+  assert_success "${PHPENV_TEST_DIR}/bin/kill-all-humans"
+}
+
+@test "searches PATH for system version (shims prepended)" {
+  create_executable "${PHPENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${PHPENV_ROOT}/shims" "kill-all-humans"
+
+  PATH="${PHPENV_ROOT}/shims:$PATH" PHPENV_VERSION=system run phpenv-which kill-all-humans
+  assert_success "${PHPENV_TEST_DIR}/bin/kill-all-humans"
+}
+
+@test "searches PATH for system version (shims appended)" {
+  create_executable "${PHPENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${PHPENV_ROOT}/shims" "kill-all-humans"
+
+  PATH="$PATH:${PHPENV_ROOT}/shims" PHPENV_VERSION=system run phpenv-which kill-all-humans
+  assert_success "${PHPENV_TEST_DIR}/bin/kill-all-humans"
+}
+
+@test "searches PATH for system version (shims spread)" {
+  create_executable "${PHPENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${PHPENV_ROOT}/shims" "kill-all-humans"
+
+  PATH="${PHPENV_ROOT}/shims:${PHPENV_ROOT}/shims:/tmp/non-existent:$PATH:${PHPENV_ROOT}/shims" \
+    PHPENV_VERSION=system run phpenv-which kill-all-humans
+  assert_success "${PHPENV_TEST_DIR}/bin/kill-all-humans"
+}
+
+@test "doesn't include current directory in PATH search" {
+  bats_require_minimum_version 1.5.0
+  mkdir -p "$PHPENV_TEST_DIR"
+  cd "$PHPENV_TEST_DIR"
+  touch kill-all-humans
+  chmod +x kill-all-humans
+  PATH="$(path_without "kill-all-humans")" PHPENV_VERSION=system run -127 phpenv-which kill-all-humans
+  assert_failure "phpenv: kill-all-humans: command not found"
+}
+
+@test "version not installed" {
+  create_executable "8.1.16" "pecl"
+  PHPENV_VERSION=8.0.16 run phpenv-which pecl
+  assert_failure "phpenv: version \`8.0.16' is not installed (set by PHPENV_VERSION environment variable)"
+}
+
+@test "no executable found" {
+  bats_require_minimum_version 1.5.0
+  create_executable "8.1.16" "pecl"
+  PHPENV_VERSION=8.1.16 run -127 phpenv-which pear
+  assert_failure "phpenv: pear: command not found"
+}
+
+@test "no executable found for system version" {
+  bats_require_minimum_version 1.5.0
+  PATH="$(path_without "pear")" PHPENV_VERSION=system run -127 phpenv-which pear
+  assert_failure "phpenv: pear: command not found"
+}
+
+@test "executable found in other versions" {
+  bats_require_minimum_version 1.5.0
+  create_executable "7.4.33" "php"
+  create_executable "8.1.16" "pecl"
+  create_executable "8.1.17" "pecl"
+
+  PHPENV_VERSION=7.4.33 run -127 phpenv-which pecl
+  assert_failure
+  assert_output <<OUT
+phpenv: pecl: command not found
+
+The \`pecl' command exists in these PHP versions:
+  8.1.16
+  8.1.17
+OUT
+}
+
+@test "carries original IFS within hooks" {
+  create_hook which hello.bash <<SH
+hellos=(\$(printf "hello\\tugly world\\nagain"))
+echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
+exit
+SH
+
+  IFS=$' \t\n' PHPENV_VERSION=system run phpenv-which anything
+  assert_success
+  assert_output "HELLO=:hello:ugly:world:again"
+}
+
+@test "discovers version from phpenv-version-name" {
+  mkdir -p "$PHPENV_ROOT"
+  cat > "${PHPENV_ROOT}/version" <<<"7.4.33"
+  create_executable "7.4.33" "php"
+
+  mkdir -p "$PHPENV_TEST_DIR"
+  cd "$PHPENV_TEST_DIR"
+
+  PHPENV_VERSION='' run phpenv-which php
+  assert_success "${PHPENV_ROOT}/versions/7.4.33/bin/php"
+}


### PR DESCRIPTION
This PR copies bats tests from upstream phpenv and ensures they pass for the following commands:

- phpenv-commands
- phpenv-which
- phpenv-version-origin

The goal is to have tests for all major components and for the behavior to match upstream