### PR TITLE
Remove apxs functionality from phpenv-global

### DIFF
--- a/libexec/phpenv-global
+++ b/libexec/phpenv-global
@@ -41,23 +41,3 @@ else
 fi
 
 echo ${PHPENV_VERSION}
-
-# Link Apache apxs lib
-rm -f "${PHPENV_ROOT}"/lib/libphp*.so
-LIBPHP_SO_FILE="libphp$(php-config --version | cut -c1).so"
-APXS=""
-if [ "${PHPENV_VERSION}" == "system" ]; then
-    DEFAULT_APXS="$(which apxs 2>/dev/null)"
-    if [ -n "${DEFAULT_APXS}" -a -f "$(${DEFAULT_APXS} -q LIBEXECDIR)/${LIBPHP_SO_FILE}" ]; then
-	APXS="${DEFAULT_APXS}"
-    fi
-fi
-php-config --configure-options 2>/dev/null | grep -q apxs  && \
-    APXS="$(php-config --configure-options| sed 's/.*=\(.*apxs[^ ]*\) .*/\1/')"
-
-[[ -d "${PHPENV_ROOT}/lib" ]] || mkdir "${PHPENV_ROOT}/lib"
-if [ -n "${APXS}" ]; then
-    [[ "${PHPENV_VERSION}" == "system" ]] && \
-        ln -fs "$(${APXS} -q LIBEXECDIR)/${LIBPHP_SO_FILE}" "${PHPENV_ROOT}/lib/${LIBPHP_SO_FILE}" || \
-        ln -fs "${PHPENV_ROOT}/versions/${PHPENV_VERSION}/libexec/${LIBPHP_SO_FILE}" "${PHPENV_ROOT}/lib/${LIBPHP_SO_FILE}";
-fi

--- a/test/global.bats
+++ b/test/global.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "default" {
+  run phpenv-global
+  assert_success
+  assert_output "system"
+}
+
+@test "read PHPENV_ROOT/version" {
+  mkdir -p "$PHPENV_ROOT"
+  echo "1.2.3" > "$PHPENV_ROOT/version"
+  run phpenv-global
+  assert_success
+  assert_output "1.2.3"
+}
+
+@test "set PHPENV_ROOT/version" {
+  mkdir -p "$PHPENV_ROOT/versions/1.2.3"
+  run phpenv-global "1.2.3"
+  assert_success
+  run phpenv-global
+  assert_success "1.2.3"
+}
+
+@test "fail setting invalid PHPENV_ROOT/version" {
+  mkdir -p "$PHPENV_ROOT"
+  run phpenv-global "1.2.3"
+  assert_failure "phpenv: version \`1.2.3' not installed"
+}


### PR DESCRIPTION
This adds tests for phpenv-global and removes the apxs functionality from phpenv.

This counts as a fix for #122 

As discussed in #122 phpenv-global does too many things. It sets / reads the global version but it also creates symlinks for the apache php extension (apxs). The second should ONLY be done if the user actually uses apache php, in other words, it belongs to a phpenv _plugin_ rather than to phpenv itself.

We should also create a stub phpenv plugin that sets the apache extension version if this extension is needed. More likely, however, most of the phpenv audience uses php-fpm.