### PR TITLE
Update phpenv exec, completions, version, versions, --version to upstream behavior with tests

### DIFF
--- a/libexec/phpenv---version
+++ b/libexec/phpenv---version
@@ -12,11 +12,12 @@
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
-version="1.0.0-rc.1"
+version="1.0.0"
 git_revision=""
 
-cd "$PHPENV_ROOT"
-git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
-git_revision="${git_revision#v}"
+if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q phpenv; then
+  git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
+  git_revision="${git_revision#v}"
+fi
 
-echo "phpenv v${git_revision:-$version}"
+echo "phpenv ${git_revision:-$version}"

--- a/libexec/phpenv-completions
+++ b/libexec/phpenv-completions
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: phpenv completions <command> [arg1 arg2...]
+# Usage: phpenv completions <command> [<args>...]
 
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
@@ -10,8 +10,17 @@ if [ -z "$COMMAND" ]; then
   exit 1
 fi
 
-COMMAND_PATH="$(command -v "phpenv-$COMMAND" || command -v "phpenv-sh-$COMMAND")"
-if grep -i "^# provide phpenv completions" "$COMMAND_PATH" >/dev/null; then
+# Provide phpenv completions
+if [ "$COMMAND" = "--complete" ]; then
+  exec phpenv-commands
+fi
+
+COMMAND_PATH="$(type -P "phpenv-$COMMAND" "phpenv-sh-$COMMAND" | head -n1)"
+
+# --help is provided automatically
+echo --help
+
+if grep -iE "^([#%]|--|//) provide phpenv completions" "$COMMAND_PATH" >/dev/null; then
   shift
   exec "$COMMAND_PATH" --complete "$@"
 fi

--- a/libexec/phpenv-exec
+++ b/libexec/phpenv-exec
@@ -2,7 +2,7 @@
 #
 # Summary: Run an executable with the selected PHP version
 #
-# Usage: phpenv exec <command> [arg1 arg2...]
+# Usage: phpenv exec <command> [<args>...]
 #
 # Runs an executable by first preparing PATH so that the selected PHP
 # version's `bin' directory is at the front.
@@ -18,10 +18,10 @@ set -e
 
 # Provide phpenv completions
 if [ "$1" = "--complete" ]; then
-  exec phpenv shims --short
+  exec phpenv-shims --short
 fi
 
-export PHPENV_VERSION="$(phpenv-version-name)"
+PHPENV_VERSION="$(phpenv-version-name)"
 PHPENV_COMMAND="$1"
 
 if [ -z "$PHPENV_COMMAND" ]; then
@@ -29,6 +29,7 @@ if [ -z "$PHPENV_COMMAND" ]; then
   exit 1
 fi
 
+export PHPENV_VERSION
 PHPENV_COMMAND_PATH="$(phpenv-which "$PHPENV_COMMAND")"
 PHPENV_BIN_PATH="${PHPENV_COMMAND_PATH%/*}"
 

--- a/libexec/phpenv-version
+++ b/libexec/phpenv-version
@@ -8,4 +8,11 @@
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
-echo "$(phpenv-version-name) (set by $(phpenv-version-origin))"
+version_name="$(phpenv-version-name)"
+version_origin="$(phpenv-version-origin)"
+
+if [ "$version_origin" = "${PHPENV_ROOT}/version" ] && [ ! -e "$version_origin" ]; then
+  echo "$version_name"
+else
+  echo "$version_name (set by $version_origin)"
+fi

--- a/libexec/phpenv-versions
+++ b/libexec/phpenv-versions
@@ -1,39 +1,83 @@
 #!/usr/bin/env bash
-# Summary: List all PHP versions available to phpenv
-# Usage: phpenv versions [--bare]
+# Summary: List installed PHP versions
+# Usage: phpenv versions [--bare] [--skip-aliases]
 #
 # Lists all PHP versions found in `$PHPENV_ROOT/versions/*'.
 
 set -e
 [ -n "$PHPENV_DEBUG" ] && set -x
 
-if [ "$1" = "--bare" ]; then
-  hit_prefix=""
-  miss_prefix=""
-  current_version=""
-  include_system=""
-else
-  hit_prefix="* "
-  miss_prefix="  "
-  current_version="$(phpenv-version-name || true)"
-  include_system="1"
-fi
+unset bare
+unset skip_aliases
+# Provide phpenv completions
+for arg; do
+  case "$arg" in
+  --complete )
+    echo --bare
+    echo --skip-aliases
+    exit ;;
+  --bare ) bare=1 ;;
+  --skip-aliases ) skip_aliases=1 ;;
+  * )
+    phpenv-help --usage versions >&2
+    exit 1
+    ;;
+  esac
+done
 
-print_version() {
-  if [ "$1" == "$current_version" ]; then
-    echo "${hit_prefix}$(phpenv-version 2>/dev/null)"
-  else
-    echo "${miss_prefix}$1"
-  fi
+canonicalize_dir() {
+  { cd "$1" && pwd -P
+  } 2>/dev/null || echo "$1"
 }
 
-# Include "system" in the non-bare output, if it exists
-if [ -n "$include_system" ] && PHPENV_VERSION=system phpenv-which php >/dev/null 2>&1; then
-  print_version system
+versions_dir="${PHPENV_ROOT}/versions"
+if [ -n "$skip_aliases" ]; then
+  versions_dir="$(canonicalize_dir "$versions_dir")"
 fi
 
-for path in "${PHPENV_ROOT}/versions/"*; do
-  if [ -d "$path" ]; then
-    print_version "${path##*/}"
+list_versions() {
+  local path
+  local target
+  shopt -s nullglob
+  for path in "$versions_dir"/*; do
+    if [ -d "$path" ]; then
+      if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
+        target="$(canonicalize_dir "$path")"
+        [ "${target%/*}" != "$versions_dir" ] || continue
+      fi
+      echo "${path##*/}"
+    fi
+  done
+  shopt -u nullglob
+}
+
+if [ -n "$bare" ]; then
+  list_versions
+  exit 0
+fi
+
+sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+versions="$(
+  if PHPENV_VERSION=system phpenv-which php >/dev/null 2>&1; then
+    echo system
   fi
-done
+  list_versions | sort_versions
+)"
+
+if [ -z "$versions" ]; then
+  echo "Warning: no PHP detected on the system" >&2
+  exit 1
+fi
+
+current_version="$(phpenv-version-name || true)"
+while read -r version; do
+  if [ "$version" == "$current_version" ]; then
+    echo "* $(phpenv-version 2>/dev/null)"
+  else
+    echo "  $version"
+  fi
+done <<<"$versions"

--- a/test/--version.bats
+++ b/test/--version.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+export GIT_DIR="${PHPENV_TEST_DIR}/.git"
+
+setup() {
+  mkdir -p "$HOME"
+  git config --global user.name  "Tester"
+  git config --global user.email "tester@test.local"
+  cd "$PHPENV_TEST_DIR"
+}
+
+git_commit() {
+  git commit --quiet --allow-empty -m "empty"
+}
+
+@test "default version" {
+  assert [ ! -e "$PHPENV_ROOT" ]
+  run phpenv---version
+  assert_success
+  [[ $output == "phpenv "?.?.? ]]
+}
+
+@test "doesn't read version from non-phpenv repo" {
+  git init
+  git remote add origin https://github.com/homebrew/homebrew.git
+  git_commit
+  git tag v1.0
+
+  run phpenv---version
+  assert_success
+  [[ $output == "phpenv "?.?.? ]]
+}
+
+@test "reads version from git repo" {
+  git init
+  git remote add origin https://github.com/phpenv/phpenv.git
+  git_commit
+  git tag v0.4.1
+  git_commit
+  git_commit
+
+  run phpenv---version
+  assert_success "phpenv 0.4.1-2-g$(git rev-parse --short HEAD)"
+}
+
+@test "prints default version if no tags in git repo" {
+  git init
+  git remote add origin https://github.com/phpenv/phpenv.git
+  git_commit
+
+  run phpenv---version
+  [[ $output == "phpenv "?.?.? ]]
+}

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_command() {
+  bin="${PHPENV_TEST_DIR}/bin"
+  mkdir -p "$bin"
+  echo "$2" > "${bin}/$1"
+  chmod +x "${bin}/$1"
+}
+
+@test "command with no completion support" {
+  create_command "phpenv-hello" "#!$BASH
+    echo hello"
+  run phpenv-completions hello
+  assert_success "--help"
+}
+
+@test "command with completion support" {
+  create_command "phpenv-hello" "#!$BASH
+# Provide phpenv completions
+if [[ \$1 = --complete ]]; then
+  echo hello
+else
+  exit 1
+fi"
+  run phpenv-completions hello
+  assert_success
+  assert_output <<OUT
+--help
+hello
+OUT
+}
+
+@test "forwards extra arguments" {
+  create_command "phpenv-hello" "#!$BASH
+# provide phpenv completions
+if [[ \$1 = --complete ]]; then
+  shift 1
+  for arg; do echo \$arg; done
+else
+  exit 1
+fi"
+  run phpenv-completions hello happy world
+  assert_success
+  assert_output <<OUT
+--help
+happy
+world
+OUT
+}

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_executable() {
+  name="${1?}"
+  shift 1
+  bin="${PHPENV_ROOT}/versions/${PHPENV_VERSION}/bin"
+  mkdir -p "$bin"
+  { if [ $# -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } | sed -Ee '1s/^ +//' > "${bin}/$name"
+  chmod +x "${bin}/$name"
+}
+
+@test "fails with invalid version" {
+  export PHPENV_VERSION="2.0"
+  run phpenv-exec php -v
+  assert_failure "phpenv: version \`2.0' is not installed (set by PHPENV_VERSION environment variable)"
+}
+
+@test "fails with invalid version set from file" {
+  mkdir -p "$PHPENV_TEST_DIR"
+  cd "$PHPENV_TEST_DIR"
+  echo 1.9 > .php-version
+  run phpenv-exec rspec
+  assert_failure "phpenv: version \`1.9' is not installed (set by $PWD/.php-version)"
+}
+
+@test "completes with names of executables" {
+  export PHPENV_VERSION="2.0"
+  create_executable "php" "#!/bin/sh"
+  create_executable "phar" "#!/bin/sh"
+
+  phpenv-rehash
+  run phpenv-completions exec
+  assert_success
+  assert_output <<OUT
+--help
+phar
+php
+OUT
+}
+
+@test "carries original IFS within hooks" {
+  create_hook exec hello.bash <<SH
+hellos=(\$(printf "hello\\tugly world\\nagain"))
+echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
+SH
+
+  export PHPENV_VERSION=system
+  IFS=$' \t\n' run phpenv-exec env
+  assert_success
+  assert_line "HELLO=:hello:ugly:world:again"
+}
+
+@test "forwards all arguments" {
+  export PHPENV_VERSION="2.0"
+  create_executable "php" <<SH
+#!$BASH
+echo \$0
+for arg; do
+  # hack to avoid bash builtin echo which can't output '-e'
+  printf "  %s\\n" "\$arg"
+done
+SH
+
+  run phpenv-exec php -w "/path to/php script.php" -- extra args
+  assert_success
+  assert_output <<OUT
+${PHPENV_ROOT}/versions/2.0/bin/php
+  -w
+  /path to/php script.php
+  --
+  extra
+  args
+OUT
+}
+
+@test "supports php -S <cmd>" {
+  export PHPENV_VERSION="2.0"
+
+  # emulate `php -S' behavior
+  create_executable "php" <<SH
+#!$BASH
+if [[ \$1 == "-S"* ]]; then
+  found="\$(PATH="\${phpPATH:-\$PATH}" which \$2)"
+  # assert that the found executable has php for shebang
+  if head -n1 "\$found" | grep php >/dev/null; then
+    \$BASH "\$found"
+  else
+    echo "php: no PHP script found in input (LoadError)" >&2
+    exit 1
+  fi
+else
+  echo 'php 2.0 (phpenv test)'
+fi
+SH
+
+  create_executable "phar" <<SH
+#!/usr/bin/env php
+echo hello phar
+SH
+
+  phpenv-rehash
+  run php -S phar
+  assert_success "hello phar"
+}

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_version() {
+  mkdir -p "${PHPENV_ROOT}/versions/$1"
+}
+
+setup() {
+  mkdir -p "$PHPENV_TEST_DIR"
+  cd "$PHPENV_TEST_DIR"
+}
+
+@test "no version selected" {
+  assert [ ! -d "${PHPENV_ROOT}/versions" ]
+  run phpenv-version
+  assert_success "system"
+}
+
+@test "set by PHPENV_VERSION" {
+  create_version "8.1.16"
+  PHPENV_VERSION=8.1.16 run phpenv-version
+  assert_success "8.1.16 (set by PHPENV_VERSION environment variable)"
+}
+
+@test "set by local file" {
+  create_version "8.1.16"
+  cat > ".php-version" <<<"8.1.16"
+  run phpenv-version
+  assert_success "8.1.16 (set by ${PWD}/.php-version)"
+}
+
+@test "set by global file" {
+  create_version "8.1.16"
+  cat > "${PHPENV_ROOT}/version" <<<"8.1.16"
+  run phpenv-version
+  assert_success "8.1.16 (set by ${PHPENV_ROOT}/version)"
+}
+
+@test "prefer local over global file" {
+  create_version "8.1.16"
+  create_version "8.4.0"
+  cat > ".php-version" <<<"8.1.16"
+  cat > "${PHPENV_ROOT}/version" <<<"8.4.0"
+  run phpenv-version
+  assert_success "8.1.16 (set by ${PWD}/.php-version)"
+}

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_version() {
+  mkdir -p "${PHPENV_ROOT}/versions/$1"
+}
+
+setup() {
+  mkdir -p "$PHPENV_TEST_DIR"
+  cd "$PHPENV_TEST_DIR"
+}
+
+stub_system_php() {
+  local stub="${PHPENV_TEST_DIR}/bin/php"
+  mkdir -p "$(dirname "$stub")"
+  touch "$stub" && chmod +x "$stub"
+}
+
+@test "no versions installed" {
+  stub_system_php
+  assert [ ! -d "${PHPENV_ROOT}/versions" ]
+  run phpenv-versions
+  assert_success "* system"
+}
+
+@test "not even system php available" {
+  PATH="$(path_without php)" run phpenv-versions
+  assert_failure
+  assert_output "Warning: no PHP detected on the system"
+}
+
+@test "bare output no versions installed" {
+  assert [ ! -d "${PHPENV_ROOT}/versions" ]
+  run phpenv-versions --bare
+  assert_success ""
+}
+
+@test "single version installed" {
+  stub_system_php
+  create_version "8.4"
+  run phpenv-versions
+  assert_success
+  assert_output <<OUT
+* system
+  8.4
+OUT
+}
+
+@test "single version bare" {
+  create_version "8.4"
+  run phpenv-versions --bare
+  assert_success "8.4"
+}
+
+@test "multiple versions" {
+  stub_system_php
+  create_version "7.4.33"
+  create_version "8.1.16"
+  create_version "8.2.10"
+  create_version "8.2.11"
+  create_version "8.2snapshot"
+  run phpenv-versions
+  assert_success
+  assert_output <<OUT
+* system
+  7.4.33
+  8.1.16
+  8.2snapshot
+  8.2.10
+  8.2.11
+OUT
+}
+
+@test "indicates current version" {
+  stub_system_php
+  create_version "8.1.16"
+  create_version "8.2.10"
+  PHPENV_VERSION=8.1.16 run phpenv-versions
+  assert_success
+  assert_output <<OUT
+  system
+* 8.1.16 (set by PHPENV_VERSION environment variable)
+  8.2.10
+OUT
+}
+
+@test "bare doesn't indicate current version" {
+  create_version "8.1.16"
+  create_version "8.2.10"
+  PHPENV_VERSION=8.1.16 run phpenv-versions --bare
+  assert_success
+  assert_output <<OUT
+8.1.16
+8.2.10
+OUT
+}
+
+@test "globally selected version" {
+  stub_system_php
+  create_version "8.1.16"
+  create_version "8.2.10"
+  cat > "${PHPENV_ROOT}/version" <<<"8.1.16"
+  run phpenv-versions
+  assert_success
+  assert_output <<OUT
+  system
+* 8.1.16 (set by ${PHPENV_ROOT}/version)
+  8.2.10
+OUT
+}
+
+@test "per-project version" {
+  stub_system_php
+  create_version "8.1.16"
+  create_version "8.2.10"
+  cat > ".php-version" <<<"8.1.16"
+  run phpenv-versions
+  assert_success
+  assert_output <<OUT
+  system
+* 8.1.16 (set by ${PHPENV_TEST_DIR}/.php-version)
+  8.2.10
+OUT
+}
+
+@test "ignores non-directories under versions" {
+  create_version "1.9"
+  touch "${PHPENV_ROOT}/versions/hello"
+
+  run phpenv-versions --bare
+  assert_success "1.9"
+}
+
+@test "lists symlinks under versions" {
+  create_version "7.4.33"
+  ln -s "7.4.33" "${PHPENV_ROOT}/versions/7.4"
+
+  run phpenv-versions --bare
+  assert_success
+  assert_output <<OUT
+7.4
+7.4.33
+OUT
+}
+
+@test "doesn't list symlink aliases when --skip-aliases" {
+  create_version "7.4.33"
+  ln -s "7.4.33" "${PHPENV_ROOT}/versions/7.4"
+  mkdir moo
+  ln -s "${PWD}/moo" "${PHPENV_ROOT}/versions/8.1"
+
+  run phpenv-versions --bare --skip-aliases
+  assert_success
+
+  assert_output <<OUT
+7.4.33
+8.1
+OUT
+}


### PR DESCRIPTION
Updates the above commands to match test behavior in upstream rbenv

Adds --skip-aliases argument to phpenv-versions to ignore alias versions
Bump internal version number without rc1